### PR TITLE
implement-graphql-resolvers-matching-typedefs-in-schema

### DIFF
--- a/_db.js
+++ b/_db.js
@@ -1,0 +1,28 @@
+// _db.js
+
+const games = [
+    { id: '1', title: 'Zelda, Tears of the Kingdom', platform: ['Switch'] },
+    { id: '2', title: 'Final Fantasy 7 Remake', platform: ['PS5', 'Xbox'] },
+    { id: '3', title: 'Elden Ring', platform: ['PS5', 'Xbox', 'PC'] },
+    { id: '4', title: 'Mario Kart', platform: ['Switch'] },
+    { id: '5', title: 'Pokemon Scarlet', platform: ['PS5', 'Xbox', 'PC'] },
+  ];
+  
+  const authors = [
+    { id: '1', name: 'mario', verified: true },
+    { id: '2', name: 'yoshi', verified: false },
+    { id: '3', name: 'peach', verified: true },
+  ];
+  
+  const reviews = [
+    { id: '1', rating: 9,  content: 'lorem ipsum', author_id: '1', game_id: '2' },
+    { id: '2', rating: 10, content: 'lorem ipsum', author_id: '2', game_id: '1' },
+    { id: '3', rating: 7,  content: 'lorem ipsum', author_id: '3', game_id: '3' },
+    { id: '4', rating: 5,  content: 'lorem ipsum', author_id: '2', game_id: '4' },
+    { id: '5', rating: 8,  content: 'lorem ipsum', author_id: '2', game_id: '5' },
+    { id: '6', rating: 7,  content: 'lorem ipsum', author_id: '1', game_id: '2' },
+    { id: '7', rating: 10, content: 'lorem ipsum', author_id: '3', game_id: '1' },
+  ];
+  
+export default { games, authors, reviews };
+  

--- a/index.js
+++ b/index.js
@@ -1,13 +1,30 @@
 import { ApolloServer } from "@apollo/server";
 import { startStandaloneServer } from "@apollo/server/standalone";
 
+// db
+import db from "./_db.js";
+
 // types
 import { typeDefs } from "./schema.js";
 
+const resolvers = {
+    Query: {
+        games() {
+            return db.games;
+        },
+        reviews() {
+            return db.reviews;
+        },
+        authors() {
+            return db.authors;
+        }
+    }
+}
+
 // server setup 
 const server = new ApolloServer({
-    typeDefs
-    // resolvers
+    typeDefs,
+    resolvers
 });
 
 const { url } = await startStandaloneServer(server, {


### PR DESCRIPTION
add hard-coded database, insert graphql resolvers matching schema typeDefs

![Screenshot from 2025-04-23 16-21-45](https://github.com/user-attachments/assets/52530ffe-3e46-4625-9717-a52cb63f0913)

![Screenshot from 2025-04-23 16-22-36](https://github.com/user-attachments/assets/147e3bd2-50af-4313-ac4e-24c896f1e86a)
